### PR TITLE
Make :ssh work with emacs-26

### DIFF
--- a/shx.el
+++ b/shx.el
@@ -796,7 +796,10 @@ commands like :pwd and :edit will work correctly.
   (if (equal host "")
       (shx-insert 'error "ssh host\n")
     (let* ((host (replace-regexp-in-string ":" "#" host))
-           (default-directory (concat "/" host ":~")))
+           (default-directory
+             (if (eq tramp-syntax 'default)
+                 (concat "/ssh:" host ":~")
+               (concat "/" host ":~"))))
       (shx))))
 
 (defun shx-cmd-sedit (file)


### PR DESCRIPTION
In emacs-26 the method part of the tramp path syntax is required by
default. Build default-directory according to tramp-syntax to
accommodate this.