### PR TITLE
allow calling shx commands with environment variables

### DIFF
--- a/shx.el
+++ b/shx.el
@@ -197,7 +197,7 @@ This function overrides `comint-input-sender'."
     (if (not shx-cmd)
         (comint-simple-send process input)
       (condition-case-unless-debug error-descriptor
-          (funcall shx-cmd (match-string 2 input))
+          (funcall shx-cmd (substitute-env-vars (match-string 2 input)))
         (error (shx-insert 'error (error-message-string error-descriptor) "\n")))
       (with-current-buffer (process-buffer process)
         ;; advance the process mark to trick comint-mode


### PR DESCRIPTION
Currently if using an `shx` command you can't use enviroment variables like you would with a shell-level call (e.g. `:e $HOME/some/file`).