### PR TITLE
Add instructions for installing via GNU Guix

### DIFF
--- a/README.org
+++ b/README.org
@@ -59,6 +59,8 @@
 * Install
 *** From MELPA
     =M-x package-install RET shx RET= to install =shx= from [[https://melpa.org/][MELPA]].
+*** From GNU Guix
+    =guix install emacs-shx= to install =shx= from [[https://guix.gnu.org/][GNU Guix]].
 *** Manually
     Add the following to your =.emacs=:
     #+begin_src elisp


### PR DESCRIPTION
`shx` was packaged for GNU Guix as of https://git.savannah.gnu.org/cgit/guix.git/commit/?id=b8901175b7103da7bfe76a392967d21e3371d50f.

----

#