### PR TITLE
Don't require docker-tramp on emacs >=29

### DIFF
--- a/shx.el
+++ b/shx.el
@@ -935,7 +935,7 @@ its own to point the process back at the local filesystem.
 
 (defun shx-cmd-docker (container-id)
   "Open a shell in a Docker container with CONTAINER-ID."
-  (if (not (require 'docker-tramp nil t))
+  (if (and (version< emacs-version "29") (not (require 'docker-tramp nil t)))
       (shx-insert 'error "Install the 'docker-tramp' package first\n")
     (let ((host
            (substring-no-properties


### PR DESCRIPTION
Emacs 29 has built in functionality to open a shell with various container runtimes. https://www.gnu.org/software/tramp/#index-method-docker