### PR TITLE
Fix deprecation warning on view command

### DIFF
--- a/shx.el
+++ b/shx.el
@@ -42,7 +42,7 @@
   "Whether to automatically disable undo in shx buffers."
   :type 'boolean)
 
-(defcustom shx-path-to-convert "convert"
+(defcustom shx-path-to-convert "magick"
   "Path to ImageMagick's convert binary."
   :type 'string)
 


### PR DESCRIPTION
When :view is ran we get a warning:

    WARNING: The convert command is deprecated in IMv7, use "magick"
    instead of "convert" or "magick convert"

Following its instructions and invoking "magick" instead of "convert" removes this warning.